### PR TITLE
Fix: removed cookie banner if any

### DIFF
--- a/src/tiktok_uploader/upload.py
+++ b/src/tiktok_uploader/upload.py
@@ -766,6 +766,9 @@ def _post_video(driver: WebDriver) -> None:
     """
     logger.debug(green("Clicking the post button"))
 
+    driver.execute_script('document.querySelector("tiktok-cookie-banner").remove()')
+    driver.implicitly_wait(1)
+
     try:
         post = WebDriverWait(driver, config["uploading_wait"]).until(
             lambda d: (el := d.find_element(By.XPATH, config["selectors"]["upload"]["post"])) and


### PR DESCRIPTION
Hi, i have added a little fix that remove the tiktok cookie banner if any, that was hiding the post button and resulting in a crash.
For some reasons it appears on my computer but other it doesnt, so in case we remove it if any.

<img width="876" height="202" alt="image" src="https://github.com/user-attachments/assets/4ee53f8e-4d3e-49ea-a45f-d686f253444f" />
